### PR TITLE
EA-1041: Add a ID to each log and show memory usage for each log entry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import http from 'http';
+import crypto from 'crypto';
 import winston from 'winston';
 import url from 'url';
 import path from 'path';
@@ -8,10 +9,23 @@ import config from 'config/config.prod';
 
 const logFile = config.logFile;
 
+const memoryFormat = winston.format((info, opts) => {
+    const memoryUsage = process.memoryUsage();
+    info.memoryUsage = {
+        rss: (memoryUsage.rss / 1024 / 1024).toFixed(2) + ' MB',
+        heapTotal: (memoryUsage.heapTotal / 1024 / 1024).toFixed(2) + ' MB',
+        heapUsed: (memoryUsage.heapUsed / 1024 / 1024).toFixed(2) + ' MB',
+        external: (memoryUsage.external / 1024 / 1024).toFixed(2) + ' MB',
+    };
+
+    return info;
+});
+
 const logger = winston.createLogger({
     format: winston.format.combine(
         winston.format.timestamp(),
-        winston.format.json()
+        memoryFormat(),
+        winston.format.json(),
     ),
     transports: [
         new winston.transports.Console(),
@@ -23,24 +37,28 @@ const onRequest = (request, response) => {
     const requestPath = url.parse(request.url).pathname;
     const input = requestPath.split('/')[2];
     const payload = Buffer.from(input, 'base64').toString();
+    const logID = crypto.createHash('SHA512')
+        .update(request.rawHeaders.reduce((a, b) => {return a + b;}) + requestPath + payload)
+        .digest('hex')
+        .slice(0, 32);
     let payloadObject = {};
-    logger.info(`Received payload ${payload}`);
+    logger.info(`Received payload ${payload}`, {id: logID});
 
     try {
         payloadObject = JSON.parse(payload);
     } catch (e) {
-        logger.error('Cannot parse payload, exiting...');
+        logger.error('Cannot parse payload, exiting...', {id: logID});
         return;
     }
 
     const {linkHash, attachmentHash, attachmentName, auth} = payloadObject;
     const shortHash = attachmentHash.substring(0, 2);
     const attachmentLocation = path.resolve(config.dataLocation, shortHash, attachmentHash);
-    logger.info(`OTL Hash ${linkHash} with attachment ${attachmentHash} requested with payload ${payload}`);
+    logger.info(`OTL Hash ${linkHash} with attachment ${attachmentHash} requested with payload ${payload}`, {id: logID});
 
     request.socket.on('close', (hadError) => {
         if (hadError) {
-            logger.info(`Socket was closed with an error. OTL Hash was ${attachmentHash} with payload ${payload}`);
+            logger.info(`Socket was closed with an error. OTL Hash was ${attachmentHash} with payload ${payload}`, {id: logID});
         }
     });
 
@@ -50,7 +68,7 @@ const onRequest = (request, response) => {
             res.setHeader('Content-Disposition', `attachment; filename="${attachmentName}"`);
         })
         .on('end', () => {
-            logger.info('Download done');
+            logger.info('Download done', {id: logID});
             axios({
                 method: 'POST',
                 url: config.apiURL,
@@ -58,12 +76,14 @@ const onRequest = (request, response) => {
                     linkHash,
                     auth
                 }
+            }).then(() => {
+                logger.info('Deleted OTL', {id: logID});
             }).catch((err) => {
-                logger.error('Could not call API, error message ' + err);
+                logger.error('Could not call API, error message ' + err, {id: logID});
             });
         })
         .on('stream', () => {
-            logger.info('Download started');
+            logger.info('Download started', {id: logID});
         })
         .pipe(response);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ const onRequest = (request, response) => {
     const logID = crypto.createHash('SHA512')
         .update(request.rawHeaders.reduce((a, b) => {return a + b;}) + requestPath + payload)
         .digest('hex')
-        .slice(0, 32);
+        .slice(0, 8);
     let payloadObject = {};
     logger.info(`Received payload ${payload}`, {id: logID});
 


### PR DESCRIPTION
Adds a sort of request ID to each log that should be unique for separate users/links but identical if a users downloads the same file again (maybe because the download was cancelled by accident).
The log ID is hashed with SHA512.

Additionally the memory usage is now logged as well using `process.memoryUsage()`.
